### PR TITLE
Completes commands: delete, process, train, generate, show

### DIFF
--- a/src/music_generation_lstm/cli.py
+++ b/src/music_generation_lstm/cli.py
@@ -120,21 +120,13 @@ def complete_delete(arg_index, word, parts):
     if arg_index == 1:
         delete_type = parts[1]
         if delete_type == "file":
-            for result_id in data_managment.get_existing_result_ids():
-                if result_id.startswith(word):
-                    yield Completion(result_id, start_position=-len(word))
+            existing_ids_completion(data_managment.get_existing_result_ids(), word)
         elif delete_type == "dataset":
-            for dataset_id in data_managment.get_existing_dataset_ids():
-                if dataset_id.startswith(word):
-                    yield Completion(dataset_id, start_position=-len(word))
+            existing_ids_completion(data_managment.get_existing_dataset_ids(), word)
         elif delete_type == "processed":
-            for processed_id in data_managment.get_existing_processed_ids():
-                if processed_id.startswith(word):
-                    yield Completion(processed_id, start_position=-len(word))
+            existing_ids_completion(data_managment.get_existing_processed_ids(), word)
         elif delete_type == "model":
-            for model_id in data_managment.get_existing_model_ids():
-                if model_id.startswith(word):
-                    yield Completion(model_id, start_position=-len(word))
+            existing_ids_completion(data_managment.get_existing_model_ids(), word)
     
 
 def complete_process(arg_index,word, parts):
@@ -142,9 +134,7 @@ def complete_process(arg_index,word, parts):
     # first the all possible dataset-id 
     # second the new processed id
     if arg_index == 0:
-        for dataset_id in data_managment.get_existing_dataset_ids():
-            if dataset_id.startswith(word):
-                yield Completion(dataset_id, start_position = -len(word))
+        existing_ids_completion(data_managment.get_existing_dataset_ids(), word)
     if arg_index == 1:
         yield Completion("[(new) processed id]", start_position = -len(word))
     
@@ -157,9 +147,7 @@ def complete_train(arg_index, word, parts):
     if arg_index == 0:
         yield Completion("[(new) model id]", start_position = -len(word))
     if arg_index == 1:
-        for processed_id in data_managment.get_existing_processed_ids():
-            if processed_id.startswith(word):
-                yield Completion(processed_id, start_position = -len(word))
+        existing_ids_completion(data_managment.get_existing_processed_ids(), word)
    
 
 def complete_generate(arg_index, word, parts):
@@ -170,9 +158,7 @@ def complete_generate(arg_index, word, parts):
     if arg_index == 0:
         yield Completion("[(new) model id]", start_position = -len(word))
     if arg_index == 1:
-        for processed_id in data_managment.get_existing_processed_ids():
-            if processed_id.startswith(word):
-                yield Completion(processed_id, start_position = -len(word))
+        existing_ids_completion(data_managment.get_existing_processed_ids(), word)
     if arg_index == 2:
         yield Completion("[(new) results id]", start_position = -len(word))
     
@@ -183,6 +169,10 @@ def complete_show(arg_index, word, parts):
             if option.startswith(word):
                 yield Completion(option, start_position=-len(word))
 
+def existing_ids_completion(existing_ids, word):
+    for id in existing_ids:
+            if id.startswith(word):
+                yield Completion(id, start_position = -len(word))
 
 def complete_help():
     logger.info("I dont know, nothing to complete")

--- a/src/music_generation_lstm/data_managment.py
+++ b/src/music_generation_lstm/data_managment.py
@@ -78,7 +78,6 @@ def delete_folder_contents(folder_path):
     Deletes folder with contents
     deletes the empty dataset folder.
     """
-
     if not os.path.exists(folder_path):
         logger.info("Path does not exist.")
         return


### PR DESCRIPTION
Zeug geändert in: cli, data_managment

1. completes commands: delete, process, train, generate, show
so when you write things in the terminal, you are suggested what options you have.
For example, with -delete, "file" or "dataset" and an id are suggested from the ids of the datasets or files that exist

- if a new id is to be specified, this is displayed in the format "[(new) model id]", otherwise the existing options available to you are displayed. For this, the results, dataset, input folders are searched through, because if you save the ids in a list or something, they would be gone again after closing the programme.
- I'm not sure whether new model_ids should be created for both generate and train commands.
- data_managment is there to manage all created ids (dataset, results, processed,...)

2. delete command can now delete processed

