### PR TITLE
Mido bug fix

### DIFF
--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -511,7 +511,7 @@ class Tokenizer:
             position_in_bar = abs_offset % beats_per_bar
 
             # Quantize position to 16th notes, since all songs from dataset are 4/4
-            position_16th = int(position_in_bar * 4)
+            position_16th = round(position_in_bar * 4)
 
             if isinstance(event, note.Note):
                 sixtuples.append(
@@ -593,7 +593,7 @@ class Tokenizer:
                 # Bar and position
                 bar = int(start_qn // qn_per_bar)
                 position_qn = start_qn % qn_per_bar
-                position_16th = int(position_qn * 4)
+                position_16th = round(position_qn * 4)
 
                 sixtuples.append(
                     Sixtuple(

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -593,7 +593,7 @@ class Tokenizer:
                 # Bar and position
                 bar = int(start_qn // qn_per_bar)
                 position_qn = start_qn % qn_per_bar
-                position_16th = round(position_qn)
+                position_16th = int(position_qn * 4)
 
                 sixtuples.append(
                     Sixtuple(
@@ -602,8 +602,12 @@ class Tokenizer:
                         pitch=str(event["note"]),
                         duration=str(quantize(duration_qn, 0.25)),
                         velocity=str(velocity),
-                        tempo=str(round(60000000 / tempo)),
+                        tempo=str(round_tempo(round(60000000 / tempo))),
                     )
                 )
+
+        sixtuples.sort(
+            key=lambda s: (int(s.bar.split("_")[1]), int(s.position.split("_")[1]), int(s.pitch.split("_")[1]))
+        )
 
         return sixtuples

--- a/src/test/main.py
+++ b/src/test/main.py
@@ -1,7 +1,8 @@
 import logging
 
+from groove_panda.config import Config
 from groove_panda.logging_config import setup_logging
-from test.test_mido_tokenizer import test_tokenize_detokenize
+from test.test_tokenizer import test_tokenize_detokenize
 
 
 def main():
@@ -11,7 +12,8 @@ def main():
 
     setup_logging(level="INFO")
     logging.getLogger(__name__).info("Starting test")
-
+    config = Config()
+    config.load_config("config_julien")
     test_tokenize_detokenize("111.mid")
 
     logging.getLogger(__name__).info("Ending test")

--- a/src/test/test_mido_tokenizer.py
+++ b/src/test/test_mido_tokenizer.py
@@ -1,6 +1,6 @@
 import os
 
-from groove_panda.config import Config, Parser, TokenizeMode
+from groove_panda.config import Config
 from groove_panda.midi import parser, writer
 from groove_panda.processing.tokenization import tokenizer as t
 
@@ -15,8 +15,6 @@ def test_tokenize_detokenize(midi_file: str):
 
     Uses mido as parser and tokenizer mode original.
     """
-    config.parser = Parser.MIDO
-    config.tokenize_mode = TokenizeMode.ORIGINAL
     tokenizer = t.Tokenizer("")
     writer.write_midi(
         "tokenize_detokenize_mido_result",


### PR DESCRIPTION
In my previous mido-integration PR, there was an issue in the way I tested the methods: instead of comparing music21 and mido during tokenization, just music21 was used. 

I have identified the problem (for the test to not work correctly) and fixed bugs in the tokenization using MidiFile, that were previously not tested.

The result should be close to the same as with music21 (no real advantage yet, since we quantize heavily with bar/position).