### PR TITLE
Improved token maps

### DIFF
--- a/src/groove_panda/cli.py
+++ b/src/groove_panda/cli.py
@@ -359,7 +359,7 @@ def start_session():
     session = PromptSession(completer=CommandCompleter())
     while True:
         try:
-            u_input = session.prompt("Music_Generation_LSTM> ")
+            u_input = session.prompt("Groove_Panda> ")
 
             if parse_command(u_input.strip()) == Command.EXIT:
                 handle_exit()

--- a/src/groove_panda/config.py
+++ b/src/groove_panda/config.py
@@ -31,6 +31,30 @@ class Parser(Enum):
     MIDO = auto()
 
 
+class Feature:
+    def __init__(self, name: str, min_value: float, max_value: float, step: float) -> None:
+        self._name = name
+        self._min_value = min_value
+        self._max_value = max_value
+        self._step = step
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def min_value(self) -> float:
+        return self._min_value
+
+    @property
+    def max_value(self) -> float:
+        return self._max_value
+
+    @property
+    def step(self) -> float:
+        return self._step
+
+
 class Config:
     # Special config settings - do not touch
     _instance: "Config | None" = None  # Holds the one-and-only instance
@@ -67,7 +91,8 @@ class Config:
     # General settings
     parser: Parser
     allowed_music_file_extensions: list[str] = EMPTY_LIST
-    feature_names: list[str] = EMPTY_LIST
+    features: list[Feature] = EMPTY_LIST
+    feature_token_separator: str = DEFAULT_STR
     model_type: str = DEFAULT_STR
     config: dict  # The entire config file will be saved here
 
@@ -77,7 +102,6 @@ class Config:
     default_tempo: int = DEFAULT_NUMBER
 
     # Generation settings
-    tempo_round_value: int = DEFAULT_NUMBER  # Rounds all tempo values
     generation_temperature: float = DEFAULT_NUMBER
 
     # Directories
@@ -233,7 +257,7 @@ class Config:
             try:
                 cast = Parser[value]
             except KeyError as e:
-                raise ValueError(f"Unknown tokenize_mode '{value}' in {self.config_path}") from e
+                raise ValueError(f"Unknown parser '{value}' in {self.config_path}") from e
             setattr(self, setting, cast)
 
         elif setting == "tokenize_mode":
@@ -241,6 +265,13 @@ class Config:
                 cast = TokenizeMode[value]
             except KeyError as e:
                 raise ValueError(f"Unknown tokenize_mode '{value}' in {self.config_path}") from e
+            setattr(self, setting, cast)
+
+        elif setting == "features":
+            try:
+                cast = [Feature(*entry) for entry in value]
+            except KeyError as e:
+                raise ValueError(f"Unknown features '{value}' in {self.config_path}") from e
             setattr(self, setting, cast)
 
         else:

--- a/src/groove_panda/generation/generate.py
+++ b/src/groove_panda/generation/generate.py
@@ -57,7 +57,8 @@ class MusicGenerator:
 
         sampled_indices = {}
         # Use config.feature_names
-        for feature in config.feature_names:
+        feature_names = [feature.name for feature in config.features]
+        for feature in feature_names:
             feature_predictions = getattr(predictions, feature)[0]
             temp = self.feature_temperatures[feature]
 
@@ -67,7 +68,7 @@ class MusicGenerator:
                 sampled_indices[feature] = self._apply_temperature_sampling(feature_predictions, temp)
 
         # Convert indices back to tokens using reverse mappings
-        tokens = {feature: self.reverse_mappings[feature][sampled_indices[feature]] for feature in config.feature_names}
+        tokens = {feature: self.reverse_mappings[feature][sampled_indices[feature]] for feature in feature_names}
 
         return Sixtuple(
             bar=tokens["bar"].split("_")[1],

--- a/src/groove_panda/models/flexible_sequence_generator.py
+++ b/src/groove_panda/models/flexible_sequence_generator.py
@@ -98,7 +98,7 @@ class FlexibleSequenceGenerator(Sequence):
         y_array = np.array(batch_y)
 
         # Split inputs into feature-wise dictionaries for multi-input model
-        x_dict = {f"input_{config.feature_names[i]}": x_array[:, :, i] for i in range(len(config.feature_names))}
+        x_dict = {f"input_{config.features[i].name}": x_array[:, :, i] for i in range(len(config.features))}
 
         # Split outputs into feature-wise arrays for multi-output model
         y_outputs = tuple(y_array[:, i] for i in range(6))

--- a/src/groove_panda/models/lazy_sequence_generator.py
+++ b/src/groove_panda/models/lazy_sequence_generator.py
@@ -77,7 +77,7 @@ class LazySequenceGenerator(Sequence):
 
         # Split inputs into feature-wise dictionaries for multi-input model
 
-        x_dict = {config.feature_names[i]: x_array[:, :, i] for i in range(len(config.feature_names))}
+        x_dict = {config.features[i].name: x_array[:, :, i] for i in range(len(config.features))}
         """
         Creates a map similar to this:
         {

--- a/src/groove_panda/models/model_training.py
+++ b/src/groove_panda/models/model_training.py
@@ -23,24 +23,19 @@ def train_model(model_id: str, processed_dataset_id: str, preset_name: str):
     file_paths = processed_io.get_processed_file_paths(processed_dataset_id)
 
     # Load metadata for vocab sizes
-    token_maps_dir = os.path.join("data/token_maps", processed_dataset_id)
+    token_maps_dir = os.path.join(config.token_maps_dir, processed_dataset_id)
     with open(os.path.join(token_maps_dir, "metadata.json")) as f:
         metadata = json.load(f)
 
     vocab_sizes = {
-        "bar": metadata[token_map_io.TOTAL_UNIQUE_BAR_TOKENS],
-        "position": metadata[token_map_io.TOTAL_UNIQUE_POSITION_TOKENS],
-        "pitch": metadata[token_map_io.TOTAL_UNIQUE_PITCH_TOKENS],
-        "duration": metadata[token_map_io.TOTAL_UNIQUE_DURATION_TOKENS],
-        "velocity": metadata[token_map_io.TOTAL_UNIQUE_VELOCITY_TOKENS],
-        "tempo": metadata[token_map_io.TOTAL_UNIQUE_TEMPO_TOKENS],
+        feature.name: metadata[token_map_io.TOTAL_UNIQUE_BLANK_TOKENS % feature.name] for feature in config.features
     }
 
     # Get preset config
     preset = config.model_presets[preset_name]
     sequence_length = preset["sequence_length"]
 
-    input_shape = (sequence_length, len(config.feature_names))
+    input_shape = (sequence_length, len(config.features))
 
     model_path = get_model_path(model_id)
 

--- a/src/groove_panda/models/plot.py
+++ b/src/groove_panda/models/plot.py
@@ -33,7 +33,7 @@ def _plot_training_history(history, model_name: str, dir_path: str):
     Plot training history showing loss and accuracy for all 6 feature outputs.
     """
 
-    feature_names = ["bar", "position", "pitch", "duration", "velocity", "tempo"]
+    feature_names = [feature.name for feature in config.features]
 
     # Create subplots: 4 rows x 3 columns (loss and accuracy for each feature)
     fig, axes = plt.subplots(4, 3, figsize=(18, 20))
@@ -96,7 +96,7 @@ def _plot_training_metrics_separate(history: History, model_name: str, dir_path:
     Alternative version: Plot loss and accuracy in separate figures for better readability.
     """
 
-    feature_names = ["bar", "position", "pitch", "duration", "velocity", "tempo"]
+    feature_names = [feature.name for feature in config.features]
 
     # Seperate loss plot
     plt.figure(figsize=(15, 10))

--- a/src/groove_panda/models/tf_custom/callbacks.py
+++ b/src/groove_panda/models/tf_custom/callbacks.py
@@ -76,7 +76,7 @@ class TerminalPrettyCallback(callbacks.Callback):
         values = [
             f"{epoch + 1:<{TerminalPrettyCallback.EPOCH_COLUMN_WIDTH}}",
             f"{f'{int(mins)}m {int(secs)}s':<{TerminalPrettyCallback.TIME_COLUMN_WIDTH}}",
-            f"{logs.get('loss', 0):<{TerminalPrettyCallback.LOSS_COLUMN_WIDTH}.{TerminalPrettyCallback.FLOAT_PRECISION}f}"  # noqa: E501    idk how to split it #REVIEW
+            f"{logs.get('loss', 0):<{TerminalPrettyCallback.LOSS_COLUMN_WIDTH}.{TerminalPrettyCallback.FLOAT_PRECISION}f}",  # noqa: E501    idk how to split it #REVIEW
         ]
         for output in outputs:
             loss_key = f"{output}_output_loss"
@@ -88,9 +88,7 @@ class TerminalPrettyCallback(callbacks.Callback):
             acc = logs.get(acc_key, 0.0)
             values.append(
                 f"{loss:.{TerminalPrettyCallback.FLOAT_PRECISION}f}, "
-                f"{acc:.{TerminalPrettyCallback.FLOAT_PRECISION}f}".ljust(
-                    TerminalPrettyCallback.COLUMN_WIDTH
-                )
+                f"{acc:.{TerminalPrettyCallback.FLOAT_PRECISION}f}".ljust(TerminalPrettyCallback.COLUMN_WIDTH)
             )
 
         # print header once on first epoch for visual clarity (makes the output appear like a table)
@@ -101,23 +99,24 @@ class TerminalPrettyCallback(callbacks.Callback):
         print(" | ".join(values))
 
 
-class EmbeddingPropertiesCallback(tf.keras.callbacks.Callback):
+class EmbeddingPropertiesCallback(tf.keras.callbacks.Callback):  # type: ignore
     """
     This callback can be used to track properties of a specified embedding layer during training,
     e.g. the dimensionality for better architecture design and exploration.
     It's not intended to be used in regular trainings
     """
-    def __init__(self, log_dir, layer_name='embedding', threshold=0.99):
+
+    def __init__(self, log_dir, layer_name="embedding", threshold=0.99):
         super().__init__()
         self.log_dir = log_dir
         self.layer_name = layer_name
         self.threshold = threshold
-        self.writer = tf.summary.create_file_writer(os.path.join(log_dir, 'embedding_svd'))
+        self.writer = tf.summary.create_file_writer(os.path.join(log_dir, "embedding_svd"))
 
     def log_singular_values(self, weights, step_label, step):
         u, s, vh = np.linalg.svd(weights, full_matrices=False)
 
-        squared_s = s ** 2
+        squared_s = s**2
         total_energy = np.sum(squared_s)
         energy_ratio = np.cumsum(squared_s) / total_energy
         effective_rank = np.searchsorted(energy_ratio, self.threshold) + 1

--- a/src/groove_panda/models/tf_custom/regularizers.py
+++ b/src/groove_panda/models/tf_custom/regularizers.py
@@ -7,9 +7,10 @@ from groove_panda.models.tf_custom.math_utils import nuclear_norm
 Regularizers are used to influence the way the parameters of a model evolve during the training.
 """
 
+
 # Registering for keras, otherwise it has problems with models that use this regularizer, e.g. when loading a config
 @register_keras_serializable(package="Custom", name="NuclearRegularizer")
-class NuclearRegularizer(tf.keras.regularizers.Regularizer):
+class NuclearRegularizer(tf.keras.regularizers.Regularizer):  # type: ignore
     """
     This is an unusual regularizer for experimenting purposes.
     It is based on the nuclear norm (aka. shadow-1-norm or trace norm).
@@ -19,6 +20,7 @@ class NuclearRegularizer(tf.keras.regularizers.Regularizer):
     so it leads to a smaller rank of the matrix.
     This is especially helpful to analyze the actually used dimensions of layers, e.g. the embedding layer.
     """
+
     def __init__(self, lambda_: float):
         """
         :param lambda_: Coefficient of the norm in the loss function, determines the strength of the regularization.
@@ -29,4 +31,4 @@ class NuclearRegularizer(tf.keras.regularizers.Regularizer):
         return self.lambda_ * nuclear_norm(x)
 
     def get_config(self):
-        return {'lambda': self.lambda_}
+        return {"lambda": self.lambda_}

--- a/src/groove_panda/models/train.py
+++ b/src/groove_panda/models/train.py
@@ -102,7 +102,8 @@ def train_model_eager(model: BaseModel, train_generator: FlexibleSequenceGenerat
         dataset_size = full_x_array.shape[0]
         train_dataset_size = int((1 - config.validation_split_proportion) * dataset_size)
 
-        logger.info("Loaded %d total subsequences from %d songs", dataset_size, len(train_generator.song_data))
+        song_word = "song" if len(train_generator.song_data) == 1 else "songs"
+        logger.info("Loaded %d total subsequences from %d %s", dataset_size, len(train_generator.song_data), song_word)
 
         logger.info("Splitting the dataset into training and validation...")
 
@@ -116,20 +117,20 @@ def train_model_eager(model: BaseModel, train_generator: FlexibleSequenceGenerat
         # Iterating over the feature axis of the tensors
 
         train_x_dict = {
-            f"input_{feature}": train_x_array[:, :, idx]  # take of each sample only the specified feature
-            for idx, feature in enumerate(config.feature_names)
+            f"input_{feature.name}": train_x_array[:, :, idx]  # take of each sample only the specified feature
+            for idx, feature in enumerate(config.features)
         }
         train_y_dict = {
-            f"output_{feature}": train_y_array[:, idx]  # take of each sample only the specified feature
-            for idx, feature in enumerate(config.feature_names)
+            f"output_{feature.name}": train_y_array[:, idx]  # take of each sample only the specified feature
+            for idx, feature in enumerate(config.features)
         }
         val_x_dict = {
-            f"input_{feature}": val_x_array[:, :, idx]  # take of each sample only the specified feature
-            for idx, feature in enumerate(config.feature_names)
+            f"input_{feature.name}": val_x_array[:, :, idx]  # take of each sample only the specified feature
+            for idx, feature in enumerate(config.features)
         }
         val_y_dict = {
-            f"output_{feature}": val_y_array[:, idx]  # take of each sample only the specified feature
-            for idx, feature in enumerate(config.feature_names)
+            f"output_{feature.name}": val_y_array[:, idx]  # take of each sample only the specified feature
+            for idx, feature in enumerate(config.features)
         }
 
         logger.info("Giving dataset to TensorFlow...")

--- a/src/groove_panda/processing/parallel_processing.py
+++ b/src/groove_panda/processing/parallel_processing.py
@@ -115,7 +115,7 @@ def parallel_process(dataset_id: str, processed_dataset_id: str):
         tempo_set |= token_sets.tempo_set
 
     sixtuple_token_maps = SixtupleTokenMaps()
-    sixtuple_token_maps.create_from_sets(bar_set, position_set, pitch_set, duration_set, velocity_set, tempo_set)
+    sixtuple_token_maps.create_from_ranges()
 
     with Pool(cpu_count()) as pool:
         pool.starmap(

--- a/src/groove_panda/processing/process.py
+++ b/src/groove_panda/processing/process.py
@@ -59,15 +59,18 @@ def numerize(sixtuples: list[Sixtuple], sixtuple_token_maps: SixtupleTokenMaps) 
 
     numeric_sixtuples = []
     for sixtuple in sixtuples:
-        numeric_sixtuple = NumericSixtuple(
-            bar_map[sixtuple.bar],
-            position_map[sixtuple.position],
-            pitch_map[sixtuple.pitch],
-            duration_map[sixtuple.duration],
-            velocity_map[sixtuple.velocity],
-            tempo_map[sixtuple.tempo],
-        )
-        numeric_sixtuples.append(numeric_sixtuple)
+        try:
+            numeric_sixtuple = NumericSixtuple(
+                bar_map[sixtuple.bar],
+                position_map[sixtuple.position],
+                pitch_map[sixtuple.pitch],
+                duration_map[sixtuple.duration],
+                velocity_map[sixtuple.velocity],
+                tempo_map[sixtuple.tempo],
+            )
+            numeric_sixtuples.append(numeric_sixtuple)
+        except KeyError as e:
+            raise KeyError(e) from e
 
     logger.info("Finished numerize.")
 

--- a/src/groove_panda/processing/process.py
+++ b/src/groove_panda/processing/process.py
@@ -10,70 +10,40 @@ logger = logging.getLogger(__name__)
 
 
 class NumericSixtuple:
-    def __init__(self, bar: int, position: int, pitch: int, duration: int, velocity: int, tempo: int):
-        self._bar = bar
-        self._position = position
-        self._pitch = pitch
-        self._duration = duration
-        self._velocity = velocity
-        self._tempo = tempo
+    def __init__(self, *values: int):
+        self._values = list(values)
+
+    def __repr__(self):
+        return f"NumericSixtuple({', '.join(str(v) for v in self.values)})"
 
     @property
-    def bar(self):
-        return self._bar
-
-    @property
-    def position(self):
-        return self._position
-
-    @property
-    def pitch(self):
-        return self._pitch
-
-    @property
-    def duration(self):
-        return self._duration
-
-    @property
-    def velocity(self):
-        return self._velocity
-
-    @property
-    def tempo(self):
-        return self._tempo
+    def values(self):
+        return self._values
 
 
 def numerize(sixtuples: list[Sixtuple], sixtuple_token_maps: SixtupleTokenMaps) -> list[NumericSixtuple]:
-    #   Turns a list of embedded token events into its numeric equivalent
-    #   Uses maps of the given tokenizer
-    #
-
     logger.info("Start numerize...")
 
-    bar_map = sixtuple_token_maps.bar_map
-    position_map = sixtuple_token_maps.position_map
-    pitch_map = sixtuple_token_maps.pitch_map
-    duration_map = sixtuple_token_maps.duration_map
-    velocity_map = sixtuple_token_maps.velocity_map
-    tempo_map = sixtuple_token_maps.tempo_map
-
     numeric_sixtuples = []
+
+    # Create a list of (feature_name, map_dict)
+    feature_maps = sixtuple_token_maps.maps  # [(name, dict), ...]
+
     for sixtuple in sixtuples:
-        try:
-            numeric_sixtuple = NumericSixtuple(
-                bar_map[sixtuple.bar],
-                position_map[sixtuple.position],
-                pitch_map[sixtuple.pitch],
-                duration_map[sixtuple.duration],
-                velocity_map[sixtuple.velocity],
-                tempo_map[sixtuple.tempo],
-            )
-            numeric_sixtuples.append(numeric_sixtuple)
-        except KeyError as e:
-            raise KeyError(e) from e
+        numeric_values = []
+        for name, mapping in feature_maps:
+            # Use getattr to get the attribute dynamically from sixtuple
+            value = getattr(sixtuple, name)
+            try:
+                numeric_value = mapping[value]
+            except KeyError as e:
+                raise KeyError(f"Value {value} for feature '{name}' not found in {mapping}") from e
+            numeric_values.append(numeric_value)
+
+        numeric_sixtuple = NumericSixtuple(*numeric_values)
+        numeric_sixtuples.append(numeric_sixtuple)
 
     logger.info("Finished numerize.")
-
     return numeric_sixtuples
 
 
@@ -85,10 +55,7 @@ def create_continuous_sequence(numeric_sixtuples: list[NumericSixtuple]) -> np.n
 
     # Convert to array format
     sequence = np.array(
-        [
-            [event.bar, event.position, event.pitch, event.duration, event.velocity, event.tempo]
-            for event in numeric_sixtuples
-        ],
+        [event.values for event in numeric_sixtuples],
         dtype=np.int32,
     )
 
@@ -117,44 +84,6 @@ def extract_subsequence(
     return x, y
 
 
-def sequenize(numeric_sixtuples: list[NumericSixtuple]):
-    """creates sequences of feature tuples (extracts feature num val from embeddednumericevent class)
-    and corresponding next event feature tuples
-    uses sliding window of size of the sequence length defined in the current config
-    X contains sequences of features of an event, y contains the next features of an event
-    X = [[1, 2], [2, 3], [3, 4]], y = [3, 4, 5]
-    sequence X[i] is followed by y[i]
-    """
-
-    logger.info("Start sequenizing...")
-
-    x, y = [], []
-
-    if len(numeric_sixtuples) < config.sequence_length + 1:
-        raise Exception("Skipped a score, since the song was shorter than the sequence length")
-
-    for i in range(len(numeric_sixtuples) - config.sequence_length):
-        input_seq = [
-            (event.bar, event.position, event.pitch, event.duration, event.velocity, event.tempo)
-            for event in numeric_sixtuples[i : i + config.sequence_length]
-        ]
-        output_event = numeric_sixtuples[i + config.sequence_length]
-        output_tuple = (
-            output_event.bar,
-            output_event.position,
-            output_event.pitch,
-            output_event.duration,
-            output_event.velocity,
-            output_event.tempo,
-        )
-
-        x.append(input_seq)
-        y.append(output_tuple)
-
-    logger.info("Finished sequenizing")
-    return x, y
-
-
 def sequence_to_model_input(sequence: list[tuple[int, int, int, int, int, int]]) -> dict[str, np.ndarray]:
     """
     Convert a sequence of numeric sixtuples to model input format
@@ -164,7 +93,7 @@ def sequence_to_model_input(sequence: list[tuple[int, int, int, int, int, int]])
     seq_array = np.array(sequence)
 
     # Create input dictionary for the model
-    feature_names = ["bar", "position", "pitch", "duration", "velocity", "tempo"]
+    feature_names = [feature.name for feature in config.features]
 
     model_input = {}
     for i, feature_name in enumerate(feature_names):

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -564,7 +564,7 @@ class Tokenizer:
         merged_events, ticks_per_beat = midi_file_utils.read_and_merge_events(midi_file)
 
         sixtuples: list[Sixtuple] = []
-        active_notes: dict = {}
+        active_notes: dict[int, list] = {}
 
         current_tempo = 500000  # microseconds per beat, default = 120bpm
         qn_per_bar = 4  # quarter notes per bar
@@ -578,6 +578,8 @@ class Tokenizer:
 
             # Note on
             elif event["type"] == "note_on":
+                if event["note"] not in active_notes:
+                    active_notes[event["note"]] = []
                 active_notes[event["note"]].append((tick, event["velocity"], current_tempo))
 
             # Note off
@@ -597,7 +599,7 @@ class Tokenizer:
                         bar=str(bar),
                         position=str(position_16th),
                         pitch=str(event["note"]),
-                        duration=str(round(duration_qn, 4)),
+                        duration=str(quantize(duration_qn, 0.25)),
                         velocity=str(velocity),
                         tempo=str(round(60000000 / tempo)),
                     )

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -435,7 +435,7 @@ class Tokenizer:
                         pitch=str(event.pitch.midi),
                         duration=str(quantize(float(event.quarterLength), 0.25)),
                         velocity=str(event.volume.velocity),
-                        tempo=str(current_tempo),
+                        tempo=str(quantize(current_tempo, 5)),
                     )
                 )
                 note_counter += 1
@@ -451,7 +451,7 @@ class Tokenizer:
                             pitch=str(chord_note.pitch.midi),
                             duration=str(quantize(float(event.quarterLength), 0.25)),
                             velocity=str(event.volume.velocity),
-                            tempo=str(current_tempo),
+                            tempo=str(quantize(current_tempo, 5)),
                         )
                     )
                     note_in_chord_counter += 1

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -435,7 +435,7 @@ class Tokenizer:
                         pitch=str(event.pitch.midi),
                         duration=str(quantize(float(event.quarterLength), 0.25)),
                         velocity=str(event.volume.velocity),
-                        tempo=str(quantize(current_tempo, 5)),
+                        tempo=str(quantize(current_tempo, 5)),  # WARNING: QUANTIZE HARDCODED
                     )
                 )
                 note_counter += 1
@@ -451,7 +451,7 @@ class Tokenizer:
                             pitch=str(chord_note.pitch.midi),
                             duration=str(quantize(float(event.quarterLength), 0.25)),
                             velocity=str(event.volume.velocity),
-                            tempo=str(quantize(current_tempo, 5)),
+                            tempo=str(quantize(current_tempo, 5)),  # WARNING: QUANTIZE HARDCODED
                         )
                     )
                     note_in_chord_counter += 1
@@ -516,7 +516,7 @@ class Tokenizer:
                         pitch=str(event["note"]),
                         duration=str(quantize(duration_qn, 0.25)),
                         velocity=str(velocity),
-                        tempo=str(round(60000000 / tempo)),
+                        tempo=str(quantize(round(60000000 / tempo), 5)),
                     )
                 )
 

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -217,10 +217,6 @@ def quantize(value: float, precision: float) -> float:
     return max(round(value / precision) * precision, precision)
 
 
-def quantize(value: float, precision: float) -> float:
-    return max(round(value / precision) * precision, precision)
-
-
 class Tokenizer:
     def __init__(self, processed_dataset_id: str = "EMPTY"):
         self.processed_dataset_id = processed_dataset_id

--- a/src/test/test_token_maps.py
+++ b/src/test/test_token_maps.py
@@ -1,0 +1,5 @@
+# from groove_panda.processing.tokenization import tokenizer as t
+
+
+def test_token_maps():
+    pass


### PR DESCRIPTION
Token maps are generated without considering the dataset. For this I made the following changes:
- Instead of relying on the dataset, used for processing, we generate complete token maps using the new FEATURES entry in config. This setting replaces FEATURE_NAMES and contains (name, min_value, max_value, step), which are mainly used to generate the token maps of this feature. FEATURES works with the modified `config.py`. Look at my `config_julien.json`, to see how to set up your `config.json`.
- This new setting is implemented everywhere (I found) where it is needed for normal program compilation. It is also implemented in some cases, to dynamically create stuff, we previously hard coded.
- All token maps are **sorted**, use **integers** and **start at 0**
- Since FEATURES isn't integrated into everything (a lot of work), some code sections are hardcoded to use my current values (I can currently only think of the quanitzation in tokenize methods of tempo and duration)

I tested the program and everything works for me, but the output hasn't really improved yet.

Here is a picture of some of the new token maps:

<img width="197" height="789" alt="image" src="https://github.com/user-attachments/assets/b0d31911-eebb-419e-a6dd-7d962af3e2b7" />
<img width="220" height="351" alt="image" src="https://github.com/user-attachments/assets/1f8a91c7-bf45-4a4f-9904-7e266fef9d13" />
<img width="232" height="251" alt="image" src="https://github.com/user-attachments/assets/1b972b30-6426-4941-9d8a-ea12f3215774" />

And the new setting:

<img width="297" height="729" alt="image" src="https://github.com/user-attachments/assets/2fecd420-d91a-4bc4-9533-d3d701d4c857" />


And metadata:

<img width="341" height="183" alt="image" src="https://github.com/user-attachments/assets/632ba435-138b-4977-b442-45c7a3f4599a" />
