### PR TITLE
Mido key implimentation

### DIFF
--- a/src/groove_panda/generation/generate.py
+++ b/src/groove_panda/generation/generate.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import logging
 
 import numpy as np
 from tensorflow.keras.models import Model  # type: ignore
@@ -8,6 +9,7 @@ from groove_panda.processing.process import sequence_to_model_input
 from groove_panda.processing.tokenization.tokenizer import Sixtuple
 
 config = Config()
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -95,8 +97,8 @@ class MusicGenerator:
 
         generation_length = config.generation_length
 
-        print(f"Starting generation with feature temperatures: {self.feature_temperatures}")
-        print(f"Generation length: {generation_length}")
+        logger.info(f"Starting generation with feature temperatures: {self.feature_temperatures}")
+        logger.info(f"Generation length: {generation_length}")
 
         if len(seed_sequence) != self.sequence_length:
             raise ValueError(f"Seed sequence must be exactly {self.sequence_length} events long")
@@ -136,7 +138,7 @@ class MusicGenerator:
             current_sequence = [*current_sequence[1:], numeric_event]
 
             if (i + 1) % 100 == 0:
-                print(f"Generated {i + 1}/{generation_length} events")
+                logger.info(f"Generated {i + 1}/{generation_length} events")
 
-        print("Generation completed")
+        logger.info("Generation completed")
         return generated_events

--- a/src/groove_panda/generation/generate_music.py
+++ b/src/groove_panda/generation/generate_music.py
@@ -19,7 +19,7 @@ def generate_music(model_name: str, input_name: str, output_name: str):
     Load model -> Load input MIDI -> Generate -> Save output
     """
 
-    print(f"Starting music generation with model: {model_name}")
+    logger.info(f"Starting music generation with model: {model_name}")
 
     # Load the trained model
     model, model_metadata = load_model(model_name)

--- a/src/groove_panda/midi/parser.py
+++ b/src/groove_panda/midi/parser.py
@@ -120,7 +120,7 @@ def _parse_midi_mido_with_key(midi_path: str) -> tuple[MidiFile, key.Key]:
         if not isinstance(analyzed_key, key.Key):
             # Fallback to C major if analysis fails
             analyzed_key = key.Key("C", "major")
-            logger.warning(f"Key analysis failed for {midi_path}, using C major as fallback")
+            logger.warning(f"Key analysis did not return a valid key for {midi_path}, using C major as fallback")
 
         return midi_file, analyzed_key
 

--- a/src/groove_panda/processing/parallel_processing.py
+++ b/src/groove_panda/processing/parallel_processing.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import logging
 from multiprocessing import Pool, cpu_count
+import os
 
 from ..midi import parser
 from . import process, processed_io
@@ -20,7 +21,9 @@ class SixtupleSets:
     tempo_set: set[str]
 
 
-def _parallel_tokenize_worker(midi_path: str, processed_dataset_id: str) -> tuple[str, list[Sixtuple], SixtupleSets]:
+def _parallel_tokenize_worker(
+    midi_path: str, processed_dataset_id: str
+) -> tuple[str, list[list[Sixtuple]], SixtupleSets]:
     """
     A worker (per cpu core) tokenizing
         1. parse
@@ -34,7 +37,7 @@ def _parallel_tokenize_worker(midi_path: str, processed_dataset_id: str) -> tupl
     parsed_midi = parser.parse_midi(midi_path)
 
     # Tokenize according to mode and type of parser
-    sixtuples = tokenizer.tokenize(parsed_midi)
+    song_versions = tokenizer.tokenize(parsed_midi)
 
     # Create sets of unique tokens (per feature)
     bar_set = set()
@@ -44,19 +47,27 @@ def _parallel_tokenize_worker(midi_path: str, processed_dataset_id: str) -> tupl
     velocity_set = set()
     tempo_set = set()
 
-    for s in sixtuples:
-        bar_set.add(s.bar)
-        position_set.add(s.position)
-        pitch_set.add(s.pitch)
-        duration_set.add(s.duration)
-        velocity_set.add(s.velocity)
-        tempo_set.add(s.tempo)
+    for version_sixtuples in song_versions:  # Iterate through each version
+        for s in version_sixtuples:  # Iterate through sixtuples in each version
+            bar_set.add(s.bar)
+            position_set.add(s.position)
+            pitch_set.add(s.pitch)
+            duration_set.add(s.duration)
+            velocity_set.add(s.velocity)
+            tempo_set.add(s.tempo)
 
-    return midi_path, sixtuples, SixtupleSets(bar_set, position_set, pitch_set, duration_set, velocity_set, tempo_set)
+    return (
+        midi_path,
+        song_versions,
+        SixtupleSets(bar_set, position_set, pitch_set, duration_set, velocity_set, tempo_set),
+    )
 
 
 def _parallel_process_worker(
-    sixtuples: list[Sixtuple], sixtuple_token_maps: SixtupleTokenMaps, midi_path: str, processed_dataset_id: str
+    song_versions: list[list[Sixtuple]],
+    sixtuple_token_maps: SixtupleTokenMaps,
+    midi_path: str,
+    processed_dataset_id: str,
 ):
     """
     A worker (per cpu core) processing
@@ -66,14 +77,19 @@ def _parallel_process_worker(
     a single sixtuple list using the given (complete) sixtuple token maps
     """
 
-    # Numerize
-    numeric_sixtuples = process.numerize(sixtuples, sixtuple_token_maps)
+    base_name = os.path.splitext(os.path.basename(midi_path))[0]
 
-    # Save as continuous sequence instead of sequenizing
-    continuous_sequence = process.create_continuous_sequence(numeric_sixtuples)
+    for i, version_sixtuples in enumerate(song_versions):
+        unique_name = f"{base_name}_original" if i == 0 else f"{base_name}_transpose{i}"
 
-    # Save .npz with continuous sequence
-    processed_io.save_continuous_data(processed_dataset_id, midi_path, continuous_sequence)
+        # Numerize
+        numeric_sixtuples = process.numerize(version_sixtuples, sixtuple_token_maps)
+
+        # Save as continuous sequence instead of sequenizing
+        continuous_sequence = process.create_continuous_sequence(numeric_sixtuples)
+
+        # Save .npz with continuous sequence
+        processed_io.save_continuous_data(processed_dataset_id, unique_name, continuous_sequence)
 
 
 def parallel_process(dataset_id: str, processed_dataset_id: str):
@@ -94,7 +110,7 @@ def parallel_process(dataset_id: str, processed_dataset_id: str):
     midi_paths = parser.get_midi_paths_from_dataset(dataset_id)
 
     with Pool(cpu_count()) as pool:
-        results: list[tuple[str, list[Sixtuple], SixtupleSets]] = pool.starmap(
+        results: list[tuple[str, list[list[Sixtuple]], SixtupleSets]] = pool.starmap(
             _parallel_tokenize_worker, [(midi_path, processed_dataset_id) for midi_path in midi_paths]
         )
 
@@ -120,7 +136,10 @@ def parallel_process(dataset_id: str, processed_dataset_id: str):
     with Pool(cpu_count()) as pool:
         pool.starmap(
             _parallel_process_worker,
-            [(sixtuples, sixtuple_token_maps, midi_path, processed_dataset_id) for midi_path, sixtuples, _ in results],
+            [
+                (song_versions, sixtuple_token_maps, midi_path, processed_dataset_id)
+                for midi_path, song_versions, _ in results
+            ],
         )
 
     #   Calls parallel_tokenize_worker

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -432,17 +432,11 @@ class Tokenizer:
         and return the tokens from that single transposition as a list.
         """
 
-        print(f"🔍 DEBUG: _tokenize_cmajor_aminor_midi_file called with: {type(parsed_midi)}")
-
         # Extract MidiFile and key from tuple
         midi_file, analyzed_key = parsed_midi
 
-        print(f"🎵 DEBUG: Original key: {analyzed_key} (mode: {analyzed_key.mode})")
-
         # Determine target key based on original mode
         target_tonic_str = "C" if analyzed_key.mode == "major" else "A"
-
-        print(f"🎯 DEBUG: Target key: {target_tonic_str}")
 
         # Calculate semitone shift needed
         original_tonic = analyzed_key.tonic
@@ -450,8 +444,6 @@ class Tokenizer:
 
         # Calculate the interval for transposition
         semitone_shift = (target_tonic.midi - original_tonic.midi) % 12
-
-        print(f"🔄 DEBUG: Semitone shift: {semitone_shift}")
 
         # Transpose the MIDI file
         transposed_midi = midi_file_utils.transpose(midi_file, semitone_shift)

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -337,29 +337,13 @@ class Tokenizer:
         self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]
     ) -> list[list[Sixtuple]]:
         """
-        Transpose through all 12 keys, return each as separate list
+        Dispatcher for ALL_KEYS tokenization - maintains consistent architecture
         """
+        if isinstance(parsed_midi, stream.Score):
+            return self._tokenize_all_keys_score_as_separate_lists(parsed_midi)
 
-        all_song_versions = []
-
-        for semitone_shift in range(12):
-            if isinstance(parsed_midi, stream.Score):
-                transposed_midi = parsed_midi.transpose(semitone_shift)
-                if transposed_midi:
-                    sixtuples = self._tokenize_score(transposed_midi)
-                else:
-                    raise Exception("Couldn't transpose score to semitone shift")
-            else:
-                midi_file, _ = parsed_midi
-                transposed_midi = midi_file_utils.transpose(midi_file, semitone_shift)
-                if transposed_midi:
-                    sixtuples = self._tokenize_midi_file(transposed_midi)
-                else:
-                    raise Exception("Couldn't transpose MIDI to semitone shift")
-
-            all_song_versions.append(sixtuples)  # Append each as separate list
-
-        return all_song_versions
+        midi_file, _ = parsed_midi
+        return self._tokenize_all_keys_midi_file_as_separate_lists(midi_file)
 
     def _tokenize_cmajor_aminor(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """
@@ -378,6 +362,22 @@ class Tokenizer:
         """
 
         return self._tokenize_score(score)
+
+    def _tokenize_all_keys_score_as_separate_lists(self, score: stream.Score) -> list[list[Sixtuple]]:
+        """
+        Transpose Music21 score through all 12 keys, return each as separate list
+        """
+        all_song_versions = []
+
+        for semitone_shift in range(12):
+            transposed_midi = score.transpose(semitone_shift)
+            if transposed_midi:
+                sixtuples = self._tokenize_score(transposed_midi)
+                all_song_versions.append(sixtuples)
+            else:
+                raise Exception("Couldn't transpose score to semitone shift")
+
+        return all_song_versions
 
     def _tokenize_cmajor_aminor_score(self, parsed_midi: stream.Score) -> list[Sixtuple]:
         """
@@ -406,6 +406,22 @@ class Tokenizer:
         """
 
         return self._tokenize_midi_file(midi_file)
+
+    def _tokenize_all_keys_midi_file_as_separate_lists(self, midi_file: MidiFile) -> list[list[Sixtuple]]:
+        """
+        Transpose Mido MidiFile through all 12 keys, return each as separate list
+        """
+        all_song_versions = []
+
+        for semitone_shift in range(12):
+            transposed_midi = midi_file_utils.transpose(midi_file, semitone_shift)
+            if transposed_midi:
+                sixtuples = self._tokenize_midi_file(transposed_midi)
+                all_song_versions.append(sixtuples)
+            else:
+                raise Exception("Couldn't transpose MIDI to semitone shift")
+
+        return all_song_versions
 
     def _tokenize_cmajor_aminor_midi_file(self, parsed_midi: tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -331,10 +331,8 @@ class Tokenizer:
         if isinstance(parsed_midi, stream.Score):
             return self._tokenize_original_key_score(parsed_midi)
 
-        if isinstance(parsed_midi, tuple):
-            midi_file, _ = parsed_midi  # Extract MidiFile, ignore key for original key mode
-            return self._tokenize_original_key_midi_file(midi_file)
-        return self._tokenize_original_key_midi_file(parsed_midi)
+        midi_file, _ = parsed_midi  # Extract MidiFile, ignore key for original key mode
+        return self._tokenize_original_key_midi_file(midi_file)
 
     def _tokenize_all_keys(self, parsed_midi: stream.Score | MidiFile | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """ """
@@ -342,10 +340,8 @@ class Tokenizer:
         if isinstance(parsed_midi, stream.Score):
             return self._tokenize_all_keys_score(parsed_midi)
 
-        if isinstance(parsed_midi, tuple):
-            midi_file, _ = parsed_midi  # Extract MidiFile, ignore key for all keys mode
-            return self._tokenize_all_keys_midi_file(midi_file)
-        return self._tokenize_all_keys_midi_file(parsed_midi)
+        midi_file, _ = parsed_midi  # Extract MidiFile, ignore key for all keys mode
+        return self._tokenize_all_keys_midi_file(midi_file)
 
     def _tokenize_cmajor_aminor(
         self, parsed_midi: stream.Score | MidiFile | tuple[MidiFile, key.Key]
@@ -358,7 +354,10 @@ class Tokenizer:
         if isinstance(parsed_midi, stream.Score):
             return self._tokenize_cmajor_aminor_score(parsed_midi)
 
-        return self._tokenize_cmajor_aminor_midi_file(parsed_midi)
+        if isinstance(parsed_midi, tuple):
+            return self._tokenize_cmajor_aminor_midi_file(parsed_midi)
+
+        raise ValueError("MIDO parser should return tuple[MidiFile, key.Key] for C_MAJOR_A_MINOR mode")
 
     def _tokenize_original_key_score(self, score: stream.Score) -> list[Sixtuple]:
         """
@@ -426,7 +425,7 @@ class Tokenizer:
                 raise Exception("Couldn't transpose MIDI to semitone shift")
         return all_tokens
 
-    def _tokenize_cmajor_aminor_midi_file(self, parsed_midi: MidiFile | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
+    def _tokenize_cmajor_aminor_midi_file(self, parsed_midi: tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """
         Transpose every piece to C major (if originally major) or A minor (if originally minor),
         and return the tokens from that single transposition as a list.

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -379,21 +379,6 @@ class Tokenizer:
 
         return self._tokenize_score(score)
 
-    def _tokenize_all_keys_score(self, score: stream.Score) -> list[Sixtuple]:
-        """
-        Transpose a music21 stream.Score through all 12 semitone steps (0 = original, +1, ..., +11)
-        and return a flat list of all tokens across every transposition.
-        """
-
-        all_tokens: list[Sixtuple] = []
-        for semitone_shift in range(12):
-            transposed_midi = score.transpose(semitone_shift)
-            if transposed_midi:
-                all_tokens.extend(self._tokenize_score(transposed_midi))
-            else:
-                raise Exception("Couldn't transpose score to semitone shift")
-        return all_tokens
-
     def _tokenize_cmajor_aminor_score(self, parsed_midi: stream.Score) -> list[Sixtuple]:
         """
         Transpose of music21 stream.Score every piece to C major (if originally major) or A minor (if originally minor),
@@ -421,22 +406,6 @@ class Tokenizer:
         """
 
         return self._tokenize_midi_file(midi_file)
-
-    def _tokenize_all_keys_midi_file(self, parsed_midi: MidiFile) -> list[Sixtuple]:
-        """
-        Transpose the score through all 12 semitone steps (0 = original, +1, ..., +11)
-        and return a flat list of all tokens across every transposition.
-        """
-
-        all_tokens: list[Sixtuple] = []
-
-        for semitone_shift in range(12):
-            transposed_midi = midi_file_utils.transpose(parsed_midi, semitone_shift)
-            if transposed_midi:
-                all_tokens.extend(self._tokenize_midi_file(transposed_midi))
-            else:
-                raise Exception("Couldn't transpose MIDI to semitone shift")
-        return all_tokens
 
     def _tokenize_cmajor_aminor_midi_file(self, parsed_midi: tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -307,7 +307,7 @@ class Tokenizer:
 
         self.sixtuple_token_maps = SixtupleTokenMaps()
 
-    def tokenize(self, parsed_midi: stream.Score | MidiFile | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
+    def tokenize(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """
         Tokenizes the parsed midi according to it's mode
         """
@@ -323,7 +323,7 @@ class Tokenizer:
 
         return sixtuples
 
-    def _tokenize_original_key(self, parsed_midi: stream.Score | MidiFile | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
+    def _tokenize_original_key(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """
         Tokenizes the parsed midi in its original key, according to the type of parsed midi
         """
@@ -334,7 +334,7 @@ class Tokenizer:
         midi_file, _ = parsed_midi  # Extract MidiFile, ignore key for original key mode
         return self._tokenize_original_key_midi_file(midi_file)
 
-    def _tokenize_all_keys(self, parsed_midi: stream.Score | MidiFile | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
+    def _tokenize_all_keys(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """ """
 
         if isinstance(parsed_midi, stream.Score):
@@ -343,9 +343,7 @@ class Tokenizer:
         midi_file, _ = parsed_midi  # Extract MidiFile, ignore key for all keys mode
         return self._tokenize_all_keys_midi_file(midi_file)
 
-    def _tokenize_cmajor_aminor(
-        self, parsed_midi: stream.Score | MidiFile | tuple[MidiFile, key.Key]
-    ) -> list[Sixtuple]:
+    def _tokenize_cmajor_aminor(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """
         Transpose every piece to C major (if originally major) or A minor (if originally minor),
         and return the tokens from that single transposition as a list.
@@ -354,10 +352,7 @@ class Tokenizer:
         if isinstance(parsed_midi, stream.Score):
             return self._tokenize_cmajor_aminor_score(parsed_midi)
 
-        if isinstance(parsed_midi, tuple):
-            return self._tokenize_cmajor_aminor_midi_file(parsed_midi)
-
-        raise ValueError("MIDO parser should return tuple[MidiFile, key.Key] for C_MAJOR_A_MINOR mode")
+        return self._tokenize_cmajor_aminor_midi_file(parsed_midi)
 
     def _tokenize_original_key_score(self, score: stream.Score) -> list[Sixtuple]:
         """

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -307,21 +307,20 @@ class Tokenizer:
 
         self.sixtuple_token_maps = SixtupleTokenMaps()
 
-    def tokenize(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
+    def tokenize(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[list[Sixtuple]]:
         """
         Tokenizes the parsed midi according to it's mode
         """
 
         if config.tokenize_mode is TokenizeMode.ORIGINAL:
             sixtuples = self._tokenize_original_key(parsed_midi)
-        elif config.tokenize_mode is TokenizeMode.ALL_KEYS:
-            sixtuples = self._tokenize_all_keys(parsed_midi)
-        elif config.tokenize_mode is TokenizeMode.C_MAJOR_A_MINOR:
+            return [sixtuples]
+        if config.tokenize_mode is TokenizeMode.ALL_KEYS:
+            return self._tokenize_all_keys_as_seperate_lists(parsed_midi)
+        if config.tokenize_mode is TokenizeMode.C_MAJOR_A_MINOR:
             sixtuples = self._tokenize_cmajor_aminor(parsed_midi)
-        else:
-            raise ValueError(f"Unsupported TOKENIZE_MODE: {config.tokenize_mode!r}")
-
-        return sixtuples
+            return [sixtuples]
+        raise ValueError(f"Unsupported TOKENIZE_MODE: {config.tokenize_mode!r}")
 
     def _tokenize_original_key(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """
@@ -334,14 +333,33 @@ class Tokenizer:
         midi_file, _ = parsed_midi  # Extract MidiFile, ignore key for original key mode
         return self._tokenize_original_key_midi_file(midi_file)
 
-    def _tokenize_all_keys(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
-        """ """
+    def _tokenize_all_keys_as_seperate_lists(
+        self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]
+    ) -> list[list[Sixtuple]]:
+        """
+        Transpose through all 12 keys, return each as separate list
+        """
 
-        if isinstance(parsed_midi, stream.Score):
-            return self._tokenize_all_keys_score(parsed_midi)
+        all_song_versions = []
 
-        midi_file, _ = parsed_midi  # Extract MidiFile, ignore key for all keys mode
-        return self._tokenize_all_keys_midi_file(midi_file)
+        for semitone_shift in range(12):
+            if isinstance(parsed_midi, stream.Score):
+                transposed_midi = parsed_midi.transpose(semitone_shift)
+                if transposed_midi:
+                    sixtuples = self._tokenize_score(transposed_midi)
+                else:
+                    raise Exception("Couldn't transpose score to semitone shift")
+            else:
+                midi_file, _ = parsed_midi
+                transposed_midi = midi_file_utils.transpose(midi_file, semitone_shift)
+                if transposed_midi:
+                    sixtuples = self._tokenize_midi_file(transposed_midi)
+                else:
+                    raise Exception("Couldn't transpose MIDI to semitone shift")
+
+            all_song_versions.append(sixtuples)  # Append each as separate list
+
+        return all_song_versions
 
     def _tokenize_cmajor_aminor(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """


### PR DESCRIPTION
We are now dual parsing.
Mido parser now uses mido (for midi parsing) and music21 (for key analysis).

Mido parser returns tuple[MidiFile, key.Key] instead of just MidiFile.
All tokenization methods now handle the new tuple format.