### PR TITLE
Tokenize bug fix

### DIFF
--- a/src/groove_panda/generation/generate_music.py
+++ b/src/groove_panda/generation/generate_music.py
@@ -47,7 +47,7 @@ def generate_music(model_name: str, input_name: str, output_name: str):
 
     score = parse_midi(input_midi_path)
     tokenizer = Tokenizer(processed_dataset_id)
-    sixtuples = tokenizer.tokenize(score)
+    sixtuples = tokenizer.tokenize_original_key(score)
 
     # Convert to numeric tuples
     seed_sequence = []

--- a/src/groove_panda/processing/tokenization/tokenizer.py
+++ b/src/groove_panda/processing/tokenization/tokenizer.py
@@ -313,7 +313,7 @@ class Tokenizer:
         """
 
         if config.tokenize_mode is TokenizeMode.ORIGINAL:
-            sixtuples = self._tokenize_original_key(parsed_midi)
+            sixtuples = self.tokenize_original_key(parsed_midi)
             return [sixtuples]
         if config.tokenize_mode is TokenizeMode.ALL_KEYS:
             return self._tokenize_all_keys_as_seperate_lists(parsed_midi)
@@ -322,7 +322,7 @@ class Tokenizer:
             return [sixtuples]
         raise ValueError(f"Unsupported TOKENIZE_MODE: {config.tokenize_mode!r}")
 
-    def _tokenize_original_key(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
+    def tokenize_original_key(self, parsed_midi: stream.Score | tuple[MidiFile, key.Key]) -> list[Sixtuple]:
         """
         Tokenizes the parsed midi in its original key, according to the type of parsed midi
         """


### PR DESCRIPTION
Tokenize call in `generate_music.py` returns list of lists, which isn't expected. I changed the method call to instead be `tokenize_original_key`, which returns a list and ignores tokenize mode, which we don't need for the input sequence, but still handles different parsers